### PR TITLE
jclulow/node-progbar#13 support an optional alternate output stream for `<ProgressBar>.log()`

### DIFF
--- a/lib/progbar.js
+++ b/lib/progbar.js
@@ -297,7 +297,7 @@ _cleanup()
 };
 
 ProgressBar.prototype._write = function
-_write(data, clear_first)
+_write(data, clear_first, stream)
 {
 	var self = this;
 	var rlif = self.pb_rlif;
@@ -332,7 +332,7 @@ _write(data, clear_first)
 		if (clear_first)
 			tty.write(ECMA48.CSI + '1' + ECMA48.CHA);
 		if (data)
-			tty.write(data);
+			(stream || tty).write(data);
 	}
 };
 
@@ -541,11 +541,12 @@ draw()
  * the progress bar, then redraw the progress bar.
  */
 ProgressBar.prototype.log = function
-log(str)
+log(str, stream)
 {
 	var self = this;
 
 	mod_assert.string(str, 'must provide a string to log');
+	mod_assert.optionalObject(stream, 'log stream is not an object');
 
 	/*
 	 * The logged string must not contain newlines:
@@ -558,7 +559,7 @@ log(str)
 		 * We've already drawn the final progress bar line, so
 		 * just write and get out.
 		 */
-		self._write(str + '\n', false);
+		self._write(str + '\n', false, stream);
 		return;
 	}
 
@@ -572,7 +573,7 @@ log(str)
 			str += ' ';
 	}
 
-	self._write(str + '\n', true);
+	self._write(str + '\n', true, stream);
 	self.draw();
 };
 


### PR DESCRIPTION
This would fix #13.

Worked in my limited testing.
