### PR TITLE
Add openbsd to UNIX_PLATFORMS var

### DIFF
--- a/lib/progbar.js
+++ b/lib/progbar.js
@@ -72,7 +72,7 @@ if (process.env.TERM) {
 /*
  * On UNIX platforms, we can generally just write to the TTY.
  */
-var UNIX_PLATFORMS = [ 'sunos', 'solaris', 'darwin', 'linux' ];
+var UNIX_PLATFORMS = [ 'sunos', 'solaris', 'darwin', 'linux', 'openbsd' ];
 var USE_READLINE = (UNIX_PLATFORMS.indexOf(process.platform) === -1);
 
 /*


### PR DESCRIPTION
Without this change `mput` fails on OpenBSD with `mput: TypeError: stream.listenerCount is not a function`.

After adding openbsd to the platforms list mput works as expected.

Possibly FreeBSD needs to be added as well, have not tested it yet.
